### PR TITLE
docs(chore): Add architecture section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ spinnaker:
 
 Or use the [examplePluginRepository](https://github.com/spinnaker-plugin-examples/examplePluginRepository) to avoid copying the plugin `.zip` artifact.
 
+## Deployment on Spinnaker 1.20.6+
+
+See the [Plugin Users Guide](https://spinnaker.io/guides/user/plugins/) and the [pf4jStagePlugin Deployment Example](https://spinnaker.io/guides/user/plugins/deploy-example/).
+
 # Debugging
 
 To debug the `random-wait-orca`  server component inside a Spinnaker service (like Orca) using IntelliJ Idea follow these steps:
@@ -45,6 +49,8 @@ To debug the `random-wait-orca`  server component inside a Spinnaker service (li
 4) Configure the Spinnaker service the same way specified above.
 5) Create a new IntelliJ run configuration for the service that has the VM option `-Dpf4j.mode=development` and does a `Build Project` before launch.
 6) Debug away...
+
+See the [Test a Pipeline Stage Plugin](https://spinnaker.io/guides/developer/plugin-creators/deck-plugin/) guide for a detailed walkthrough of setting up a plugin local testing environment on your workstation.
 
 # Videos
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 Spinnaker Plugin (PF4J-based) that is a custom pipeline stage.
 The [pf4jStagePlugin](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin) creates a custom pipeline stage that waits a random number of seconds before signaling success.
+<<<<<<< HEAD
 This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca.
+=======
+This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/master/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleStage.java) PF4J extension point in Orca.
+>>>>>>> 36744e8... Incorporate review feedback
 The plugin consists of a `random-wait-orca` [Kotlin](https://kotlinlang.org/docs/reference/) server component and a `random-wait-deck` [React](https://reactjs.org/) UI component that uses the [rollup.js](https://rollupjs.org/guide/en/#plugins-overview) plugin library.
 
 This is for demo only and not meant to be used in a production environment.
@@ -61,24 +65,28 @@ To debug the `random-wait-orca`  server component inside a Spinnaker service (li
 
 ## `random-wait-orca`
 
-This component implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca and  consists of five classes in the `io.armory.plugin.state.wait.random` package:
+This component implements the [SimpleStage](https://github.com/spinnaker/orca/blob/master/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleStage.java) PF4J extension point in Orca and  consists of five classes in the `io.armory.plugin.state.wait.random` package:
 
 * `Context.kt`: a data class that stores the `maxWaitTime` value; `SimpleStage` uses `Context`
-* `Output.kt`: a data class that stores the `timeToWait` getValue; this data is returned to the extension point implementation and can be used in later stages
+* `Output.kt`: a data class that stores the `timeToWait` getValue; this data is returned to the extension point implementation and can be used in downstream stages
 * `RandomWaitConfig.kt`: a data class with the `@ExtensionConfiguration` tag; key-value pairs in this class map to the plugin's configuration
-* `RandomWaitInput.kt`: a data class that contains the key-values pairs that we care about from the Context map
+* `RandomWaitInput.kt`: a data class that contains the key-value pairs that we care about from the Context map
 * `RandomWaitPlugin.kt`: this is the plugin's main class; implements `SimpleStage`
+
+When adding a stage to a pipeline in the Spinnaker UI, the user can select this `Armory.RandomWaitPlugin` stage from the **Type** dropdown list. You enter a `maxWaitTime`, which is deserialized in `RandomWaitInput`.
 
 Watch [How to build a PLUGIN: Creating a Spinnaker-native custom stage](https://youtu.be/b7BmMY1kR10) and read [code comments](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/tree/master/random-wait-orca/src/main/kotlin/io/armory/plugin/stage/wait/random) for more information.
 
 ## `random-wait-deck`
 
-This component uses the [`rollup.js`](https://rollupjs.org/guide/en/#plugins-overview) plugin library to create a UI widget for Deck.
+Prior to v1.1.4, this component used the [`rollup.js`](https://rollupjs.org/guide/en/#plugins-overview) plugin library to create a UI widget for Deck.
 
 * `rollup.config.js`: configuration for building the JavaScript application
 * `package.json`: defines dependencies
 * `RandomWaitStage.tsx`: defines the custom pipeline stage; renders UI output
 * `RandomWaitStageIndex.ts`: exports the name and custom stages
 
-Watch [How to build a PLUGIN: Building the frontend for a Spinnaker-native custom stage](https://youtu.be/u9NVlG58NYo) and read [code comments](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/tree/master/random-wait-deck/src) for details.
-
+The code was refactored in v1.1.5 to use the new Deck UI SDK. `rollup.config.js`
+now points to the config defined by the UI SDK. It's mostly not necessary to
+define your own build config. This is also true of `tsconfig.json`. If you use
+the UI SDK, you no longer define how your TypeScript should be compiled.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,8 @@
 ![Latest Kork](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/workflows/Latest%20Kork/badge.svg?branch=master)
 ![Latest Orca](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/workflows/Latest%20Orca/badge.svg?branch=master)
 
-Spinnaker Plugin (PF4J-based) that is a custom pipeline stage.
-The [pf4jStagePlugin](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin) creates a custom pipeline stage that waits a random number of seconds before signaling success.
-<<<<<<< HEAD
-This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca.
-=======
-This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/master/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleStage.java) PF4J extension point in Orca.
->>>>>>> 36744e8... Incorporate review feedback
-The plugin consists of a `random-wait-orca` [Kotlin](https://kotlinlang.org/docs/reference/) server component and a `random-wait-deck` [React](https://reactjs.org/) UI component that uses the [rollup.js](https://rollupjs.org/guide/en/#plugins-overview) plugin library.
+
+The [pf4jStagePlugin](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin), also called the RandomWait plugin, creates a custom pipeline stage that waits a random number of seconds before signaling success.
 
 This is for demo only and not meant to be used in a production environment.
 
@@ -63,6 +57,8 @@ To debug the `random-wait-orca`  server component inside a Spinnaker service (li
 
 # Architecture
 
+The plugin consists of a `random-wait-orca` [Kotlin](https://kotlinlang.org/docs/reference/) server component and a `random-wait-deck` [React](https://reactjs.org/) UI component that uses the [rollup.js](https://rollupjs.org/guide/en/#plugins-overview) plugin library.
+
 ## `random-wait-orca`
 
 This component implements the [SimpleStage](https://github.com/spinnaker/orca/blob/master/orca-api/src/main/java/com/netflix/spinnaker/orca/api/simplestage/SimpleStage.java) PF4J extension point in Orca and  consists of five classes in the `io.armory.plugin.state.wait.random` package:
@@ -84,7 +80,7 @@ Prior to v1.1.4, this component used the [`rollup.js`](https://rollupjs.org/guid
 * `rollup.config.js`: configuration for building the JavaScript application
 * `package.json`: defines dependencies
 * `RandomWaitStage.tsx`: defines the custom pipeline stage; renders UI output
-* `RandomWaitStageIndex.ts`: exports the name and custom stages
+* `index.ts`: exports the name and custom stages
 
 The code was refactored in v1.1.5 to use the new Deck UI SDK. `rollup.config.js`
 now points to the config defined by the UI SDK. It's mostly not necessary to

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 ![Latest Kork](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/workflows/Latest%20Kork/badge.svg?branch=master)
 ![Latest Orca](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/workflows/Latest%20Orca/badge.svg?branch=master)
 
-Spinnaker Plugin (PF4J-based) that is a custom pipeline stage. 
-The [pf4jStagePlugin](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin) creates a custom pipeline stage that waits a random number of seconds before signaling success. 
-This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca. 
+Spinnaker Plugin (PF4J-based) that is a custom pipeline stage.
+The [pf4jStagePlugin](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin) creates a custom pipeline stage that waits a random number of seconds before signaling success.
+This plugin implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca.
 The plugin consists of a `random-wait-orca` [Kotlin](https://kotlinlang.org/docs/reference/) server component and a `random-wait-deck` [React](https://reactjs.org/) UI component that uses the [rollup.js](https://rollupjs.org/guide/en/#plugins-overview) plugin library.
 
 This is for demo only and not meant to be used in a production environment.
 
 # Version Compatibility
- 
+
 | Plugin  | Spinnaker Platform |
 |:----------- | :--------- |
 | 1.0.x  |  1.19.x |
@@ -48,9 +48,37 @@ To debug the `random-wait-orca`  server component inside a Spinnaker service (li
 5) Create a new IntelliJ run configuration for the service that has the VM option `-Dpf4j.mode=development` and does a `Build Project` before launch.
 6) Debug away...
 
-# Video walkthroughs
+# Videos
 
-* `Plugging into the UI` [video walkthrough](https://youtu.be/u9NVlG58NYo)
-* `Plugging into Spinnaker Services` [video walkthrough](https://drive.google.com/open?id=1JPkXG5NnXowb1OElAFj2VjnpvUDA-Wyi)
-* `Plugin Build and Release` [video walkthrough](https://drive.google.com/file/d/16DIo812nRyan2CDCTuZvsgN4D9yl0Dur/view?usp=sharing)
-* `Plugin Delivery` [video walkthrough](https://drive.google.com/file/d/1k-MUgmwWFdh6YiozmFw5Y2hGSm84UeTw/view?usp=sharing)
+* [Intro to Spinnaker Plugins](https://youtu.be/HtkXeC8a38Y), 2020 Spinnaker Gardening Days
+* [How to build a PLUGIN: Building the frontend for a Spinnaker-native custom stage](https://youtu.be/u9NVlG58NYo)
+* [How to build a PLUGIN: Creating a Spinnaker-native custom stage](https://youtu.be/b7BmMY1kR10)
+* [Backend Plugin Development](https://drive.google.com/open?id=1JPkXG5NnXowb1OElAFj2VjnpvUDA-Wyi)
+* [How to build a PLUGIN: The build process for a Spinnaker plugin](https://youtu.be/-AIOXdgvNqs)
+* [How to build a PLUGIN: Delivering a plugin to your Spinnaker environment](https://youtu.be/G2eyc9gzNS0)
+
+# Architecture
+
+## `random-wait-orca`
+
+This component implements the [SimpleStage](https://github.com/spinnaker/orca/blob/ab89a0d7f847205ccd62e70f8a714040a8621ee7/orca-api/src/main/java/com/netflix/spinnaker/orca/api/SimpleStage.java) PF4J extension point in Orca and  consists of five classes in the `io.armory.plugin.state.wait.random` package:
+
+* `Context.kt`: a data class that stores the `maxWaitTime` value; `SimpleStage` uses `Context`
+* `Output.kt`: a data class that stores the `timeToWait` getValue; this data is returned to the extension point implementation and can be used in later stages
+* `RandomWaitConfig.kt`: a data class with the `@ExtensionConfiguration` tag; key-value pairs in this class map to the plugin's configuration
+* `RandomWaitInput.kt`: a data class that contains the key-values pairs that we care about from the Context map
+* `RandomWaitPlugin.kt`: this is the plugin's main class; implements `SimpleStage`
+
+Watch [How to build a PLUGIN: Creating a Spinnaker-native custom stage](https://youtu.be/b7BmMY1kR10) and read [code comments](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/tree/master/random-wait-orca/src/main/kotlin/io/armory/plugin/stage/wait/random) for more information.
+
+## `random-wait-deck`
+
+This component uses the [`rollup.js`](https://rollupjs.org/guide/en/#plugins-overview) plugin library to create a UI widget for Deck.
+
+* `rollup.config.js`: configuration for building the JavaScript application
+* `package.json`: defines dependencies
+* `RandomWaitStage.tsx`: defines the custom pipeline stage; renders UI output
+* `RandomWaitStageIndex.ts`: exports the name and custom stages
+
+Watch [How to build a PLUGIN: Building the frontend for a Spinnaker-native custom stage](https://youtu.be/u9NVlG58NYo) and read [code comments](https://github.com/spinnaker-plugin-examples/pf4jStagePlugin/tree/master/random-wait-deck/src) for details.
+

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ To debug the `random-wait-orca`  server component inside a Spinnaker service (li
 
 # Videos
 
-* [Intro to Spinnaker Plugins](https://youtu.be/HtkXeC8a38Y), 2020 Spinnaker Gardening Days
+* [Intro to Spinnaker Plugins](https://youtu.be/HtkXeC8a38Y), 2020 April Spinnaker Gardening Days
+* [Plugins Training Workshop](https://youtu.be/oEHPvO88ROA), 2020 July Spinnaker Gardening Days
 * [How to build a PLUGIN: Building the frontend for a Spinnaker-native custom stage](https://youtu.be/u9NVlG58NYo)
 * [How to build a PLUGIN: Creating a Spinnaker-native custom stage](https://youtu.be/b7BmMY1kR10)
 * [Backend Plugin Development](https://drive.google.com/open?id=1JPkXG5NnXowb1OElAFj2VjnpvUDA-Wyi)


### PR DESCRIPTION
Moved the pf4jStagePlugin architecture section from "Pipeline Stage Plugin Walkthrough" in the Spinnaker docs. That whole page is gone. I'm moving plugin architecture content here and moved other content to the new Test a Pipeline Stage plugin page.

Updated the videos section to include those done for Gardening Days.

