### PR TITLE
fix(release): upgrade spinnakerGradle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.parallel=true
 
-spinnakerGradleVersion=8.0.4
+spinnakerGradleVersion=8.2.0
 pf4jVersion=3.2.0
 korkVersion=7.45.9
 orcaVersion=8.8.0


### PR DESCRIPTION
This PR is about upgrade `spinnakerGradle` plugin to avoid removed plugin metadata on MANIFEST.